### PR TITLE
fix: listener callback should bind this

### DIFF
--- a/packages/appkit-universal/appKitClient.ts
+++ b/packages/appkit-universal/appKitClient.ts
@@ -21,6 +21,7 @@ export class WalletConnectModal extends Web3ModalScaffold {
 	private universalProvider: Awaited<ReturnType<(typeof UniversalProvider)['init']>>
 	private requestedScope: string
 	private requestedNamespaces: Exclude<ConnectParams['optionalNamespaces'], undefined>
+	private _onSyncAccount: WalletConnectModal['syncAccount'] | undefined
 
 	public constructor(options: Web3ModalClientOptions) {
 		const { universalProvider, namespaces, ...w3mOptions } = options
@@ -104,8 +105,10 @@ export class WalletConnectModal extends Web3ModalScaffold {
 		])
 		this.syncAccount()
 		this.syncNetwork()
-		universalProvider.client.on('session_update', this.syncAccount)
-		universalProvider.client.on('session_delete', this.syncAccount)
+
+		this._onSyncAccount = this.syncAccount.bind(this)
+		universalProvider.client.on('session_update', this._onSyncAccount)
+		universalProvider.client.on('session_delete', this._onSyncAccount)
 	}
 
 	async disconnect() {

--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -39,6 +39,8 @@ export class WalletConnectWalletAdapter extends BaseSignerWalletAdapter {
 	private _readyState: WalletReadyState =
 		typeof window === 'undefined' ? WalletReadyState.Unsupported : WalletReadyState.Loadable
 
+	private _onDisconnect: WalletConnectWalletAdapter['disconnect'] | undefined
+
 	constructor(config: WalletConnectWalletAdapterConfig) {
 		super()
 
@@ -52,6 +54,8 @@ export class WalletConnectWalletAdapter extends BaseSignerWalletAdapter {
 					: WalletConnectChainID.Devnet,
 			options: this._config.options,
 		})
+
+		this._onDisconnect = this.disconnect.bind(this)
 	}
 
 	get publicKey() {
@@ -76,7 +80,7 @@ export class WalletConnectWalletAdapter extends BaseSignerWalletAdapter {
 			const { publicKey } = await this._wallet.connect()
 			this._publicKey = publicKey
 			this.emit('connect', publicKey)
-			this._wallet.client.on('session_delete', this.disconnect)
+			this._wallet.client.on('session_delete', this._onDisconnect)
 		} catch (error: unknown) {
 			if ((error as Error).constructor.name === 'QRCodeModalError') throw new WalletWindowClosedError()
 			throw error

--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -92,7 +92,7 @@ export class WalletConnectWalletAdapter extends BaseSignerWalletAdapter {
 	async disconnect(): Promise<void> {
 		const wallet = this._wallet
 		if (wallet) {
-			wallet.client.off('session_delete', this.disconnect)
+			wallet.client.off('session_delete', this._onDisconnect)
 			this._publicKey = null
 
 			try {


### PR DESCRIPTION
when disconnect from wallet app,this lib will throw  below error:
```text
TypeError: this.resetAccount is not a function
    at EventEmitter.syncAccount (appKitClient.js:93:1)
    at EventEmitter.emit (events.js:158:1)
    at Zt.deleteSession (index.es.js:1:1)
    at async EventEmitter.<anonymous> (index.es.js:1:1)
```

It is because forget bind this for listener callback 