### PR TITLE
fix: Adapter isConnected handling on preemptive modal close

### DIFF
--- a/packages/walletconnect-solana/package.json
+++ b/packages/walletconnect-solana/package.json
@@ -33,6 +33,7 @@
 	"devDependencies": {
 		"@solana/wallet-adapter-base": "^0.9.23",
 		"@solana/web3.js": "1.98.0",
+		"@types/node": "22.14.1",
 		"@walletconnect/types": "2.19.0",
 		"typescript": "^5.5.2"
 	},

--- a/packages/walletconnect-solana/src/adapter.ts
+++ b/packages/walletconnect-solana/src/adapter.ts
@@ -76,6 +76,7 @@ export class WalletConnectWalletAdapter extends BaseSignerWalletAdapter {
       if (this.connected || this.connecting) {
         return
       }
+
       if (this._readyState !== WalletReadyState.Loadable) {
         throw new WalletNotReadyError()
       }
@@ -93,9 +94,10 @@ export class WalletConnectWalletAdapter extends BaseSignerWalletAdapter {
       this.emit('connect', publicKey)
       this._wallet.client.on('session_delete', this._onDisconnect)
     } catch (error: unknown) {
-      if ((error as Error).constructor.name === 'QRCodeModalError') {
+      if ((error as Error).constructor.name === 'QRCodeModalError' || error instanceof Error && error.name === 'QRCodeModalError') {
         throw new WalletWindowClosedError()
       }
+      this._connecting = false
       throw error
     } finally {
       this._connecting = false

--- a/packages/walletconnect-solana/src/core.ts
+++ b/packages/walletconnect-solana/src/core.ts
@@ -21,6 +21,7 @@ import type {
   WalletConnectWalletInit
 } from './types.js'
 import { getConnectParams, getDefaultChainFromSession } from './utils.js'
+import { QRCodeModalError } from './errors/QRCodeModalError.js'
 
 export class WalletConnectWallet {
   private _UniversalProvider: UniversalProviderType | undefined
@@ -68,20 +69,44 @@ export class WalletConnectWallet {
     await this.initModal()
     const params = getConnectParams(this._network)
     this._modal?.open()
-    const session = await this._UniversalProvider?.connect(params)
-    this._modal?.close()
-    this._session = session
-    if (!session) {
-      throw new WalletConnectionError()
-    }
-    const defaultNetwork = getDefaultChainFromSession(
-      session,
-      this._network
-    ) as WalletConnectChainID
-    this._network = defaultNetwork
-    this._UniversalProvider?.setDefaultChain(defaultNetwork)
 
-    return { publicKey: this.publicKey }
+    // Create an abort controller to handle modal close
+    const controller = new AbortController()
+    const signal = controller.signal
+
+    this._modal?.subscribeState((state) => {
+      console.log('>> Modal state changed', state.open)
+      if (!state.open) {
+        controller.abort(new QRCodeModalError())
+      }
+    })
+    
+    try {
+      const session = await Promise.race([
+        this._UniversalProvider?.connect(params),
+        new Promise<never>((_, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(signal.reason)
+          })
+        })
+      ])
+      this._modal?.close()
+      this._session = session
+      if (!session) {
+        throw new WalletConnectionError()
+      }
+      const defaultNetwork = getDefaultChainFromSession(
+        session,
+        this._network
+      ) as WalletConnectChainID
+      this._network = defaultNetwork
+      this._UniversalProvider?.setDefaultChain(defaultNetwork)
+
+      return { publicKey: this.publicKey }
+    } catch (error) {
+      this._modal?.close()
+      throw error
+    }
   }
 
   async disconnect() {

--- a/packages/walletconnect-solana/src/core.ts
+++ b/packages/walletconnect-solana/src/core.ts
@@ -75,7 +75,6 @@ export class WalletConnectWallet {
     const signal = controller.signal
 
     this._modal?.subscribeState((state) => {
-      console.log('>> Modal state changed', state.open)
       if (!state.open) {
         controller.abort(new QRCodeModalError())
       }

--- a/packages/walletconnect-solana/src/errors/QRCodeModalError.ts
+++ b/packages/walletconnect-solana/src/errors/QRCodeModalError.ts
@@ -1,8 +1,9 @@
 export class QRCodeModalError extends Error {
   constructor() {
-    super()
+    super('QR Code Modal was closed by user')
 
     // Set the prototype explicitly.
     Object.setPrototypeOf(this, QRCodeModalError.prototype)
+    this.name = 'QRCodeModalError'
   }
 }


### PR DESCRIPTION
## Summary
Fixes issue where closing the modal without connecting would leave the adapter in a broken state with `isConnecting` permanently true, preventing the modal from opening